### PR TITLE
Log stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,11 @@ You can pass in `gt`,`gte`,`lt`,`lte` options similar to levelup.
 
 #### mdb.createKeyStream([options])
 
-Similar to `createReadSTream` but only returns keys
+Similar to `createReadStream` but only returns keys
+
+#### mdb.createLogStream([options])
+
+Get a stream of all `{key:key, value:doc}` pairs in the log (all revisions of docs). Works about 10x faster than createValueStream, but returns all revisions, even merged ones.
 
 #### mdb.merge(key, docs, newValue, [cb])
 

--- a/index.js
+++ b/index.js
@@ -158,6 +158,18 @@ var create = function (db, opts) {
     return link(keys, fmt)
   }
 
+  that.createLogStream = function (opts) {
+    if (!opts) opts = {}
+    var e = opts.encoding ? encoders(opts.encoding) : enc
+
+    var stream = log.createReadStream({ valueEncoding: 'binary' })
+    var fmt = through.obj(function (data, enc, cb) {
+      var entry = messages.Entry.decode(data.entry)
+      cb(null, { key: entry.key, value: e.decode(entry.value) })
+    })
+    return link(stream, fmt)
+  }
+
   that.put = function (key, val, opts, cb) {
     if (typeof opts === 'function') return that.put(key, val, null, opts)
     if (!opts) opts = {}

--- a/test/basic.js
+++ b/test/basic.js
@@ -111,6 +111,30 @@ tape('key stream', function (t) {
   })
 })
 
+tape('log stream', function (t) {
+  var db = create()
+
+  db.put('hello', {hello: 'world'}, function (err) {
+    t.notOk(err)
+    db.put('hej', {hej: 'verden'}, function (err) {
+      t.notOk(err)
+
+      var i = 0
+      var strm = db.createLogStream()
+      strm.on('data', function (dta) {
+        if (++i === 1) {
+          t.equal(dta.value.hello, 'world')
+        } else {
+          t.equal(dta.value.hej, 'verden')
+        }
+      })
+      strm.on('end', function () {
+        t.end()
+      })
+    })
+  })
+})
+
 tape('postupdate', function (t) {
   var postupdate = function (data, cb) {
     t.same(data.key, 'hello')


### PR DESCRIPTION
Implements ``.createLogStream``, which is useful for couple of things

* Get all revisions of documents that have ever existed in the log - practically a wrapper over scuttleup createReadStream
* Get all documents in the log much faster than createValueStream - *this one will be more useful if GC-ing merged revisions is implemented, since it would return only documents that createReadStream would return*