### PR TITLE
implement opts.gc

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,13 @@ var create = function (db, opts) {
         }, function (err) {
           if (err) return cb(err)
           seqs.put(data.peer, '' + data.seq, function () {
+            if (opts.gc) {
+              heads.forEach(function (key) {
+                var parts = split(key)
+                log.del(parts[0], parts[1])
+              })
+            }
+
             postupdate(d, function (err) {
               if (data.peer === log.id) call(head = data.seq)
               cb(err)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "fwdb": "^2.1.0",
     "level-sublevel": "^6.3.15",
     "protocol-buffers": "^2.4.0",
-    "scuttleup": "^3.1.0",
+    "scuttleup": "^3.3.0",
     "through2": "^0.6.3"
   },
   "devDependencies": {


### PR DESCRIPTION
@mafintosh can you check this out?

it's a simple change, setting opts.gc will now delete old heads from the log when doing a merge

_PS_ I rebased this because my first commit didn't pass standard
